### PR TITLE
Fixed infinite stamina from being activated by infinite damage

### DIFF
--- a/ModMain.cs
+++ b/ModMain.cs
@@ -45,7 +45,7 @@ namespace DebugMod
                 PatchQuest.Player.P2.GrantImmunity(1f);
             }
 
-            // Infinite Damage
+            // Infinite Stamina
             if (CheatsMenu.InfiniteStamina)
             {
                 // Setting stamina for both players to maximum possible value

--- a/ModMain.cs
+++ b/ModMain.cs
@@ -46,7 +46,7 @@ namespace DebugMod
             }
 
             // Infinite Damage
-            if (CheatsMenu.InfiniteDamage)
+            if (CheatsMenu.InfiniteStamina)
             {
                 // Setting stamina for both players to maximum possible value
                 PatchQuest.Player.P1.Stamina = int.MaxValue;


### PR DESCRIPTION
Infinite stamina was being activated by `CheatsMenu.InfiniteDamage` instead of `CheatsMenu.InfiniteStamina`