### PR TITLE
Remove ModdingUtilities

### DIFF
--- a/DebugMod.csproj
+++ b/DebugMod.csproj
@@ -45,9 +45,6 @@
     <Reference Include="MelonLoader">
       <HintPath>A:\Program Files v2\Steam_Moment\steamapps\common\Patch Quest\MelonLoader\MelonLoader.dll</HintPath>
     </Reference>
-    <Reference Include="ModdingUtilities">
-      <HintPath>A:\Program Files v2\Steam_Moment\steamapps\common\Patch Quest\Mods\ModdingUtilities.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/ModMain.cs
+++ b/ModMain.cs
@@ -42,8 +42,15 @@ namespace DebugMod
         #endregion
 
         #region Update
-        public override void MainUpdate()
+        public void Update()
         {
+            if(PatchQuest.Game.State != PatchQuest.GameState.NONE)
+            {
+                // We don't want to run any of the features while not ingame, because it can cause problems
+                // So instead we just return out if we are not ingame
+                return;
+            }
+
             // Toggles active state of DebugMenu when F6 is pressed
             if (Input.GetKeyDown(KeyCode.F6))
             {

--- a/ModMain.cs
+++ b/ModMain.cs
@@ -1,12 +1,11 @@
 ﻿using DebugMod.Features.Visual;
 using DebugMod.GUI;
 using MelonLoader;
-using ModdingUtilities;
 using UnityEngine;
 
 namespace DebugMod
 {
-    public class ModMain : PatchQuestMod
+    public class ModMain : MelonMod
     {
         public static ModMain Instance;
 


### PR DESCRIPTION
#24 

ModdingUtilities kinda sucks, and I'm currently phasing it out. My plan is to instead use separate libraries for different things when they are necessary, instead of just having one thing to do it all. Plus there isn't much that needs a library right now so it's fine to just do it in the actual mod